### PR TITLE
Dense vae pmm

### DIFF
--- a/xca/ml/tf_data_proc.py
+++ b/xca/ml/tf_data_proc.py
@@ -225,6 +225,7 @@ def build_dataset(
     val_split,
     data_shape,
     n_classes=0,
+    preprocess=None,
 ):
     """
     Constructs training dataset for categorical classification or continuous regression from
@@ -242,6 +243,8 @@ def build_dataset(
     n_classes: int
         Number of classes for classification (if categorical).
         Defaults to 0 with no explicit assumption of classification.
+    preprocess: callable, None
+        Optional preprocessing override
 
     Returns
     -------
@@ -261,18 +264,31 @@ def build_dataset(
             lambda e: parse_categorical_TFR(e, data_shape),
             num_parallel_calls=multiprocessing,
         )
-        dataset = dataset.map(
-            lambda d, l: categorical_preprocess(d, l, n_classes),
-            num_parallel_calls=multiprocessing,
-        )
+        if preprocess is None:
+            dataset = dataset.map(
+                lambda d, l: categorical_preprocess(d, l, n_classes),
+                num_parallel_calls=multiprocessing,
+            )
+        else:
+            dataset = dataset.map(
+                lambda d, l: preprocess(d, l, n_classes),
+                num_parallel_calls=multiprocessing,
+            )
     else:
         dataset = dataset.map(
             lambda e: parse_continuous_TFR(e, data_shape),
             num_parallel_calls=multiprocessing,
         )
-        dataset = dataset.map(
-            lambda d, l: continuous_preprocess(d, l), num_parallel_calls=multiprocessing
-        )
+        if preprocess is None:
+            dataset = dataset.map(
+                lambda d, l: continuous_preprocess(d, l),
+                num_parallel_calls=multiprocessing,
+            )
+        else:
+            dataset = dataset.map(
+                lambda d, l: preprocess(d, l),
+                num_parallel_calls=multiprocessing,
+            )
     train_dataset = dataset.take(train_size)
     val_dataset = dataset.skip(train_size)
     train_dataset = train_dataset.batch(batch_size)

--- a/xca/ml/tf_models.py
+++ b/xca/ml/tf_models.py
@@ -139,12 +139,12 @@ class VAE(Model):
         )
         return z_mean + K.exp(z_log_sigma) * epsilon
 
-    def encode(self, x):
-        mean, log_var = self.encoder(x)
+    def encode(self, x, *args, **kwargs):
+        mean, log_var = self.encoder(x, *args, **kwargs)
         return mean, log_var
 
-    def decode(self, z):
-        logits = self.decoder(z)
+    def decode(self, z, *args, **kwargs):
+        logits = self.decoder(z, *args, **kwargs)
         if not self.decode_logits:
             probs = tf.sigmoid(logits)
         else:
@@ -152,9 +152,9 @@ class VAE(Model):
         return probs
 
     def __call__(self, x, *args, **kwargs):
-        z_mean, z_log_sigma = self.encode(x)
-        z = self.sample(z_mean, z_log_sigma)
-        reconstruction = self.decode(z)
+        z_mean, z_log_sigma = self.encode(x, *args, **kwargs)
+        z = Lambda(self.sample)([z_mean, z_log_sigma], *args, **kwargs)
+        reconstruction = self.decode(z, *args, **kwargs)
         return {
             "z_mean": z_mean,
             "z_log_sigma": z_log_sigma,

--- a/xca/ml/tf_models.py
+++ b/xca/ml/tf_models.py
@@ -71,7 +71,7 @@ def build_dense_decoder_model(
         number of variables defining the latent distribution
     activation: string
         specifies activation function for hidden layers
-    dense_dim: list of int
+    dense_dims: list of int
         dimensions of hidden layers in encoder model (default is [256, 128])
     verbose: bool
         if True, prints out model summary (default is False)
@@ -95,17 +95,17 @@ class VAE(Model):
         self.decoder = decoder
         self.kl_loss_weight = kl_loss_weight
 
-    def kl_loss(z_mean, z_log_sigma):
+    def kl_loss(self, z_mean, z_log_sigma):
         kl_loss = 1 + z_log_sigma - K.square(z_mean) - K.exp(z_log_sigma)
         kl_loss = K.sum(kl_loss, axis=-1)
         kl_loss *= -0.5
         return kl_loss
 
-    def reconstruction_loss(data, reconstruction):
+    def reconstruction_loss(self, data, reconstruction):
         reconstruction_loss = tf.keras.losses.binary_crossentropy(data, reconstruction)
         return reconstruction_loss
 
-    def sample(z_mean, z_log_sigma):
+    def sample(self, z_mean, z_log_sigma):
         epsilon = K.random_normal(
             shape=(K.shape(z_mean)[0], K.shape(z_mean)[1]), mean=0.0, stddev=1
         )


### PR DESCRIPTION
1. Apply black. Double check you are using the dev instructions and have pre-commit hooks set up in your repo. 
2. Made static VAE methods static. 
3. Build a __call__ method to super the Model call. This is pretty experimental on my end, but should work and provide a bit of convenience with turning things like Training (backprop) on and off elegantly. When we do things like validation, or deployment, we want a way to call `vae.encode(x, training=False)`
4. First pass at a training protocol for the VAE. 
5. Lastly some docs and adjustment to data classes. It looks like the design here depends on a sigmoid output and crossentropy loss instead of MSE loss. That means our input data needs to be on [0,1]. This should be fine; however, the default preprocessing was to cast the data on [-1,1]. The tfrecords and datasets are stored as [0,1] though, so no sweat.